### PR TITLE
Adding rate-limiting parameter to the SC configuration

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -76,6 +76,8 @@ var scConfiguration = ClientConfiguration{
 	ClientStatusTimeout:  15,
 	KGPHandshakeTimeout:  15,
 	MaxMissedAcks:        300,
+	ScproxyWriteLimit:    100,
+	ScproxyReadLimit:     100,
 	ServerStatusInterval: 10,
 	ServerStatusTimeout:  5,
 	StartTimeout:         45,

--- a/client_types.go
+++ b/client_types.go
@@ -119,6 +119,8 @@ type ClientConfiguration struct {
 	ClientStatusInterval int             `json:"client_status_interval,omitempty"`
 	ClientStatusTimeout  int             `json:"client_status_timeout,omitempty"`
 	Regions              []region.Region `json:"regions,omitempty"`
+	ScproxyWriteLimit    int             `json:"scproxy_write_limit,omitempty"`
+	ScproxyReadLimit     int             `json:"scproxy_read_limit,omitempty"`
 	ServerStatusInterval int             `json:"server_status_interval,omitempty"`
 	ServerStatusTimeout  int             `json:"server_status_timeout,omitempty"`
 	StartTimeout         int             `json:"start_timeout,omitempty"`

--- a/client_utils_test.go
+++ b/client_utils_test.go
@@ -16,8 +16,9 @@ const (
 		"YWNrcyI6MzAwLCJjbGllbnRfc3RhdHVzX2ludGVydmFsIjozMCwiY2xpZW50X3N0" +
 		"YXR1c190aW1lb3V0IjoxNSwicmVnaW9ucyI6W3sibmFtZSI6InVzLXdlc3QiLCJ1" +
 		"cmwiOiJodHRwczovL2FwaS51cy13ZXN0LTEuc2F1Y2VsYWJzLmNvbS9yZXN0L3Yx" +
-		"In1dLCJzZXJ2ZXJfc3RhdHVzX2ludGVydmFsIjoxMCwic2VydmVyX3N0YXR1c190" +
-		"aW1lb3V0Ijo1LCJzdGFydF90aW1lb3V0Ijo0NX0" +
+		"In1dLCJzY3Byb3h5X3dyaXRlX2xpbWl0IjoxMDAsInNjcHJveHlfcmVhZF9saW1p" +
+		"dCI6MTAwLCJzZXJ2ZXJfc3RhdHVzX2ludGVydmFsIjoxMCwic2VydmVyX3N0YXR1" +
+		"c190aW1lb3V0Ijo1LCJzdGFydF90aW1lb3V0Ijo0NX0" +
 		"%3D&region=us-west&tunnel_name=my-tunnel&tunnel_pool=true"
 )
 


### PR DESCRIPTION
Allow passing read/write rate-limiting parameters via the configuration received in /updates response