### PR TITLE
Add h2c protocol

### DIFF
--- a/client.go
+++ b/client.go
@@ -237,12 +237,7 @@ func (c *Client) getTunnelOwnerUsername() string {
 func (c *Client) listSharedTunnels(protocol ...Protocol) (map[string][]TunnelState, error) {
 	states := make(map[string][]TunnelState)
 
-	protocolQuery := ""
-	if len(protocol) > 0 {
-		protocolQuery = fmt.Sprintf("&protocol=%s", protocolsToString(protocol, ","))
-	}
-
-	url := fmt.Sprintf("%s/%s/tunnels?full=1&all=1%s", c.BaseURL, c.getTunnelOwnerUsername(), protocolQuery)
+	url := fmt.Sprintf("%s/%s/tunnels?full=1&all=1%s", c.BaseURL, c.getTunnelOwnerUsername(), protocolQuery(protocol))
 	err := c.executeRequest(context.Background(), http.MethodGet, url, nil, &states)
 
 	return states, err
@@ -252,12 +247,7 @@ func (c *Client) listSharedTunnels(protocol ...Protocol) (map[string][]TunnelSta
 func (c *Client) listTunnels(protocol ...Protocol) ([]TunnelState, error) {
 	var states []TunnelState
 
-	protocolQuery := ""
-	if len(protocol) > 0 {
-		protocolQuery = fmt.Sprintf("&protocol=%s", protocolsToString(protocol, ","))
-	}
-
-	url := fmt.Sprintf("%s/%s/tunnels?full=1%s", c.BaseURL, c.getTunnelOwnerUsername(), protocolQuery)
+	url := fmt.Sprintf("%s/%s/tunnels?full=1%s", c.BaseURL, c.getTunnelOwnerUsername(), protocolQuery(protocol))
 	err := c.executeRequest(context.Background(), http.MethodGet, url, nil, &states)
 
 	return states, err

--- a/client_tunnel.go
+++ b/client_tunnel.go
@@ -13,7 +13,7 @@ func (c *Client) CreateTunnel(
 	// Releases resources if the request completes before timeout elapses.
 	defer cancel()
 
-	return c.create(ctx, request, SCProtocol)
+	return c.create(ctx, request)
 }
 
 // ListAllTunnelStates returns all the tunnels (including not currently running)
@@ -34,8 +34,9 @@ func (c *Client) ListAllTunnelStates(limit int) ([]TunnelState, error) {
 }
 
 // ListSharedTunnels returns tunnel IDs per user for a given org with shared tunnels.
-func (c *Client) ListSharedTunnels() (map[string][]string, error) {
-	tunnels, err := c.listSharedTunnels(SCProtocol)
+// Filter results by one or more protocol, or leave empty for all protocols.
+func (c *Client) ListSharedTunnels(protocol ...Protocol) (map[string][]string, error) {
+	tunnels, err := c.listSharedTunnels(protocol...)
 	if err != nil {
 		return nil, err
 	}
@@ -44,13 +45,15 @@ func (c *Client) ListSharedTunnels() (map[string][]string, error) {
 }
 
 // ListSharedTunnelStates returns tunnels per user for a given org with shared tunnels.
-func (c *Client) ListSharedTunnelStates() (map[string][]TunnelState, error) {
-	return c.listSharedTunnels(SCProtocol)
+// Filter results by one or more protocol, or leave empty for all protocols.
+func (c *Client) ListSharedTunnelStates(protocol ...Protocol) (map[string][]TunnelState, error) {
+	return c.listSharedTunnels(protocol...)
 }
 
 // ListTunnels returns tunnel IDs for a given user.
-func (c *Client) ListTunnels() ([]string, error) {
-	states, err := c.listTunnels(SCProtocol)
+// Filter results by one or more protocol, or leave empty for all protocols.
+func (c *Client) ListTunnels(protocol ...Protocol) ([]string, error) {
+	states, err := c.listTunnels(protocol...)
 	if err != nil {
 		return nil, err
 	}
@@ -59,13 +62,13 @@ func (c *Client) ListTunnels() ([]string, error) {
 }
 
 // ListTunnelStates returns KGP tunnel states for a given user.
-func (c *Client) ListTunnelStates() ([]TunnelState, error) {
-	return c.listTunnels(SCProtocol)
+func (c *Client) ListTunnelStates(protocol ...Protocol) ([]TunnelState, error) {
+	return c.listTunnels(protocol...)
 }
 
 // ShutdownTunnel terminates tunnel. Termination 'reason' could be
 // "sigterm", "serverTimeout", etc... Boolean "wait" determines whether the server
 // should wait for jobs to finish.
 func (c *Client) ShutdownTunnel(ctx context.Context, id string, reason string, wait bool) (int, error) {
-	return c.shutdown(ctx, id, reason, wait, SCProtocol)
+	return c.shutdown(ctx, id, reason, wait)
 }

--- a/client_types.go
+++ b/client_types.go
@@ -42,12 +42,12 @@ type jsonRequest struct {
 	Metadata         Metadata  `json:"metadata"`
 	NoProxyCaching   bool      `json:"no_proxy_caching"`
 	NoSSLBumpDomains *[]string `json:"no_ssl_bump_domains"`
+	Protocol         *string   `json:"protocol"`
 	SharedTunnel     bool      `json:"shared_tunnel"`
 	SquidConfig      *string   `json:"squid_config"`
 	SSHPort          int       `json:"ssh_port"`
 	TunnelIdentifier *string   `json:"tunnel_identifier"`
 	TunnelPool       bool      `json:"tunnel_pool"`
-	UseKGP           bool      `json:"use_kgp"`
 	VMVersion        *string   `json:"vm_version"`
 }
 
@@ -63,6 +63,7 @@ type Request struct {
 	KGPPort          int
 	NoProxyCaching   bool
 	NoSSLBumpDomains []string
+	Protocol         string
 	SharedTunnel     bool
 	TunnelPool       bool
 	VMVersion        string

--- a/client_utils.go
+++ b/client_utils.go
@@ -80,12 +80,15 @@ func sharedTunnelStatesToIDs(states map[string][]TunnelState) map[string][]strin
 	return tunnelIDs
 }
 
-func pathByProto(protocol Protocol) string {
-	path := "tunnels"
-
-	if protocol == VPNProtocol {
-		path = "vpns"
+// ProtocolstoString converts an array of Protocols to a delimited string.
+func protocolsToString(protocols []Protocol, delimiter string) string {
+	cs := ""
+	if len(protocols) > 0 {
+		cs = protocols[0].String()
+		for _, p := range protocols[1:] {
+			cs += fmt.Sprintf("%s%s", delimiter, p.String())
+		}
 	}
 
-	return path
+	return cs
 }

--- a/client_utils.go
+++ b/client_utils.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/url"
 	"path"
+	"strings"
+	"unsafe"
 )
 
 // Decode `reader` into the object `v`, and close `reader` after.
@@ -80,15 +82,10 @@ func sharedTunnelStatesToIDs(states map[string][]TunnelState) map[string][]strin
 	return tunnelIDs
 }
 
-// ProtocolstoString converts an array of Protocols to a delimited string.
-func protocolsToString(protocols []Protocol, delimiter string) string {
-	cs := ""
-	if len(protocols) > 0 {
-		cs = protocols[0].String()
-		for _, p := range protocols[1:] {
-			cs += fmt.Sprintf("%s%s", delimiter, p.String())
-		}
+func protocolQuery(protocols []Protocol) string {
+	if len(protocols) == 0 {
+		return ""
 	}
 
-	return cs
+	return fmt.Sprintf("&protocol=%s", strings.Join(*(*[]string)(unsafe.Pointer(&protocols)), ","))
 }

--- a/client_utils_test.go
+++ b/client_utils_test.go
@@ -124,3 +124,35 @@ func Test_urlGenerator(t *testing.T) {
 		})
 	}
 }
+
+func TestProtocolQuery(t *testing.T) {
+	tests := []struct {
+		name      string
+		protocols []Protocol
+		want      string
+	}{
+		{
+			"no protocols",
+			nil,
+			"",
+		},
+		{
+			"one protocol",
+			[]Protocol{H2CProtocol},
+			"&protocol=h2c",
+		},
+		{
+			"two protocols",
+			[]Protocol{H2CProtocol, KGPProtocol},
+			"&protocol=h2c,kgp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := protocolQuery(tt.protocols); got != tt.want {
+				t.Errorf("protocolQuery() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/client_vpn.go
+++ b/client_vpn.go
@@ -10,10 +10,11 @@ func (c *Client) CreateVPNProxy(
 	ctx context.Context, request *Request, timeout time.Duration,
 ) (TunnelStateWithMessages, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
+	request.Protocol = string(VPNProtocol)
 	// Releases resources if the request completes before timeout elapses.
 	defer cancel()
 
-	return c.create(ctx, request, VPNProtocol)
+	return c.create(ctx, request)
 }
 
 // ListVPNProxies returns VPN proxy IDs for a given user.
@@ -50,5 +51,5 @@ func (c *Client) ListSharedVPNStates() (map[string][]TunnelState, error) {
 // Boolean "wait" determines whether the server
 // should wait for jobs to finish.
 func (c *Client) ShutdownVPNProxy(ctx context.Context, id string, reason string, wait bool) (int, error) {
-	return c.shutdown(ctx, id, reason, wait, VPNProtocol)
+	return c.shutdown(ctx, id, reason, wait)
 }


### PR DESCRIPTION
* Add the `Protocol` parameter to `Request` and `jsonRequest` 
* Add `...Protocol` parameter to all `client.ListTunnel` and `client.ListSharedTunnel` methods
* Use `tunnels` endpoint for all queries, replacing `vpns` for IPSec tunnels
* Use `protocol=` query field, replacing `backend=`
