### PR TITLE
Adding TLS passthrough/resign domains

### DIFF
--- a/client.go
+++ b/client.go
@@ -319,20 +319,22 @@ func (c *Client) create(
 	req := request
 
 	doc := jsonRequest{
-		DirectDomains:    &req.DirectDomains,
-		DomainNames:      req.DomainNames,
-		ExtraInfo:        &req.ExtraInfo,
-		FastFailRegexps:  &req.FastFailRegexps,
-		Metadata:         req.Metadata,
-		NoProxyCaching:   req.NoProxyCaching,
-		NoSSLBumpDomains: &req.NoSSLBumpDomains,
-		SharedTunnel:     req.SharedTunnel,
-		SquidConfig:      nil,
-		SSHPort:          req.KGPPort,
-		Protocol:         &req.Protocol,
-		TunnelIdentifier: &req.TunnelIdentifier,
-		TunnelPool:       req.TunnelPool,
-		VMVersion:        &req.VMVersion,
+		DirectDomains:         &req.DirectDomains,
+		DomainNames:           req.DomainNames,
+		ExtraInfo:             &req.ExtraInfo,
+		FastFailRegexps:       &req.FastFailRegexps,
+		Metadata:              req.Metadata,
+		NoProxyCaching:        req.NoProxyCaching,
+		NoSSLBumpDomains:      &req.NoSSLBumpDomains,
+		SharedTunnel:          req.SharedTunnel,
+		SquidConfig:           nil,
+		SSHPort:               req.KGPPort,
+		Protocol:              &req.Protocol,
+		TLSPassthroughDomains: &req.TLSPassthroughDomains,
+		TLSResignDomains:      &req.TLSResignDomains,
+		TunnelIdentifier:      &req.TunnelIdentifier,
+		TunnelPool:            req.TunnelPool,
+		VMVersion:             &req.VMVersion,
 	}
 
 	tunnel := TunnelStateWithMessages{}

--- a/client_types.go
+++ b/client_types.go
@@ -35,20 +35,22 @@ type Metadata struct {
 
 //nolint:maligned
 type jsonRequest struct {
-	DirectDomains    *[]string `json:"direct_domains"`
-	DomainNames      []string  `json:"domain_names"`
-	ExtraInfo        *string   `json:"extra_info"`
-	FastFailRegexps  *[]string `json:"fast_fail_regexps"`
-	Metadata         Metadata  `json:"metadata"`
-	NoProxyCaching   bool      `json:"no_proxy_caching"`
-	NoSSLBumpDomains *[]string `json:"no_ssl_bump_domains"`
-	Protocol         *string   `json:"protocol"`
-	SharedTunnel     bool      `json:"shared_tunnel"`
-	SquidConfig      *string   `json:"squid_config"`
-	SSHPort          int       `json:"ssh_port"`
-	TunnelIdentifier *string   `json:"tunnel_identifier"`
-	TunnelPool       bool      `json:"tunnel_pool"`
-	VMVersion        *string   `json:"vm_version"`
+	DirectDomains         *[]string `json:"direct_domains"`
+	DomainNames           []string  `json:"domain_names"`
+	ExtraInfo             *string   `json:"extra_info"`
+	FastFailRegexps       *[]string `json:"fast_fail_regexps"`
+	Metadata              Metadata  `json:"metadata"`
+	NoProxyCaching        bool      `json:"no_proxy_caching"`
+	NoSSLBumpDomains      *[]string `json:"no_ssl_bump_domains"`
+	Protocol              *string   `json:"protocol"`
+	SharedTunnel          bool      `json:"shared_tunnel"`
+	SquidConfig           *string   `json:"squid_config"`
+	SSHPort               int       `json:"ssh_port"`
+	TLSPassthroughDomains *[]string `json:"tls_passthrough_domains"`
+	TLSResignDomains      *[]string `json:"tls_resign_domains"`
+	TunnelIdentifier      *string   `json:"tunnel_identifier"`
+	TunnelPool            bool      `json:"tunnel_pool"`
+	VMVersion             *string   `json:"vm_version"`
 }
 
 // Request for a new tunnel.
@@ -58,15 +60,17 @@ type Request struct {
 	DomainNames      []string
 	TunnelIdentifier string
 
-	DirectDomains    []string
-	FastFailRegexps  []string
-	KGPPort          int
-	NoProxyCaching   bool
-	NoSSLBumpDomains []string
-	Protocol         string
-	SharedTunnel     bool
-	TunnelPool       bool
-	VMVersion        string
+	DirectDomains         []string
+	FastFailRegexps       []string
+	KGPPort               int
+	NoProxyCaching        bool
+	NoSSLBumpDomains      []string
+	Protocol              string
+	SharedTunnel          bool
+	TLSPassthroughDomains []string
+	TLSResignDomains      []string
+	TunnelPool            bool
+	VMVersion             string
 
 	// Metadata contains the request metadata.
 	Metadata Metadata


### PR DESCRIPTION
SC-5 will support a list of regexes for TLS resign/passthrough.

Unlike NoSSLBumpDomains, these slices will contain regexes.