### PR TITLE
modernize Request and remove jsonRequest

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,16 +5,16 @@ run:
 linters:
   enable-all: true
   disable:
-    - wrapcheck
-    - testpackage
-    - gochecknoglobals
+    - cyclop
     - exhaustivestruct
     - exhaustruct
-    - paralleltest
+    - gochecknoglobals
     - godox
-    - cyclop
+    - paralleltest
     - tagliatelle
+    - testpackage
     - varnamelen
+    - wrapcheck
   fast: false
 
 # Settings for specific linters

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - testpackage
     - varnamelen
     - wrapcheck
+    - wsl
   fast: false
 
 # Settings for specific linters

--- a/client.go
+++ b/client.go
@@ -314,7 +314,7 @@ func (c *Client) shutdown(ctx context.Context, id string, reason string, wait bo
 // create requests Sauce Labs REST API to provision a new tunnel.
 func (c *Client) create(
 	ctx context.Context,
-	req *Request,
+	req *CreateTunnelRequestV4,
 ) (TunnelStateWithMessages, error) {
 	var tunnel TunnelStateWithMessages
 

--- a/client.go
+++ b/client.go
@@ -312,10 +312,7 @@ func (c *Client) shutdown(ctx context.Context, id string, reason string, wait bo
 }
 
 // create requests Sauce Labs REST API to provision a new tunnel.
-func (c *Client) create(
-	ctx context.Context,
-	req *CreateTunnelRequestV4,
-) (TunnelStateWithMessages, error) {
+func (c *Client) create(ctx context.Context, req any) (TunnelStateWithMessages, error) {
 	var tunnel TunnelStateWithMessages
 
 	url := fmt.Sprintf("%s/%s/tunnels", c.BaseURL, c.getTunnelOwnerUsername())

--- a/client.go
+++ b/client.go
@@ -314,38 +314,14 @@ func (c *Client) shutdown(ctx context.Context, id string, reason string, wait bo
 // create requests Sauce Labs REST API to provision a new tunnel.
 func (c *Client) create(
 	ctx context.Context,
-	request *Request,
+	req *Request,
 ) (TunnelStateWithMessages, error) {
-	req := request
-
-	doc := jsonRequest{
-		DirectDomains:         &req.DirectDomains,
-		DomainNames:           req.DomainNames,
-		ExtraInfo:             &req.ExtraInfo,
-		FastFailRegexps:       &req.FastFailRegexps,
-		Metadata:              req.Metadata,
-		NoProxyCaching:        req.NoProxyCaching,
-		NoSSLBumpDomains:      &req.NoSSLBumpDomains,
-		SharedTunnel:          req.SharedTunnel,
-		SquidConfig:           nil,
-		SSHPort:               req.KGPPort,
-		Protocol:              &req.Protocol,
-		TLSPassthroughDomains: &req.TLSPassthroughDomains,
-		TLSResignDomains:      &req.TLSResignDomains,
-		TunnelIdentifier:      &req.TunnelIdentifier,
-		TunnelPool:            req.TunnelPool,
-		VMVersion:             &req.VMVersion,
-	}
-
-	tunnel := TunnelStateWithMessages{}
+	var tunnel TunnelStateWithMessages
 
 	url := fmt.Sprintf("%s/%s/tunnels", c.BaseURL, c.getTunnelOwnerUsername())
+	err := c.executeRequest(ctx, http.MethodPost, url, req, &tunnel)
 
-	if err := c.executeRequest(ctx, http.MethodPost, url, doc, &tunnel); err != nil {
-		return tunnel, err
-	}
-
-	return tunnel, nil
+	return tunnel, err
 }
 
 // GetSCUpdates retrieves user messages, and the client version/platform

--- a/client_test.go
+++ b/client_test.go
@@ -128,7 +128,7 @@ func createTunnelWithTime(url string, timeout time.Duration) (*Client, TunnelSta
 		DomainNames: []string{"sauce-connect.proxy"},
 	}
 
-	tunnel, err := client.CreateTunnel(context.Background(), &request, timeout)
+	tunnel, err := client.CreateTunnelV4(context.Background(), &request, timeout)
 	return client, tunnel, err
 }
 
@@ -919,11 +919,11 @@ func TestClientCreateHTTPError(t *testing.T) {
 	defer server.Close()
 
 	_, _, err := createTunnel(server.URL)
-	assert.Error(err, "client.CreateTunnel error is expected")
+	assert.Error(err, "client.CreateTunnelV4 error is expected")
 
 	var clientError *ClientError
 	if !errors.As(err, &clientError) {
-		t.Errorf("client.CreateTunnel ClientError is expected, found %+v", err)
+		t.Errorf("client.CreateTunnelV4 ClientError is expected, found %+v", err)
 	}
 	assert.Equalf(expectedHTTPStatuscode, clientError.StatusCode,
 		"Invalid error, got %d expected %d, %s", clientError.StatusCode, expectedHTTPStatuscode, err)
@@ -945,10 +945,10 @@ func TestClientErrorMessage(t *testing.T) {
 
 	if _, _, err := createTunnel(server.URL); err != nil {
 		assert.NotEqual(nil, err,
-			"Expected client.CreateTunnel error is missing")
+			"Expected client.CreateTunnelV4 error is missing")
 		var clientError *ClientError
 		if !errors.As(err, &clientError) {
-			t.Errorf("client.CreateTunnel ClientError is expected, found %+v", err)
+			t.Errorf("client.CreateTunnelV4 ClientError is expected, found %+v", err)
 		}
 
 		assert.Equalf(expectedHTTPStatuscode, clientError.StatusCode,

--- a/client_test.go
+++ b/client_test.go
@@ -124,7 +124,7 @@ func createTunnelWithTime(url string, timeout time.Duration) (*Client, TunnelSta
 		APIKey:  "password",
 	}
 
-	request := Request{
+	request := CreateTunnelRequestV4{
 		DomainNames: []string{"sauce-connect.proxy"},
 	}
 
@@ -853,7 +853,7 @@ func TestClientCreateVPN(t *testing.T) {
 		APIKey:      "password",
 	}
 
-	request := Request{
+	request := CreateTunnelRequestV4{
 		DomainNames: []string{"sauce-connect.proxy"},
 	}
 

--- a/client_tunnel.go
+++ b/client_tunnel.go
@@ -16,6 +16,17 @@ func (c *Client) CreateTunnelV4(
 	return c.create(ctx, req)
 }
 
+// CreateTunnelV5 requests Sauce Labs REST API to create a new Sauce Connect 5 tunnel.
+func (c *Client) CreateTunnelV5(
+	ctx context.Context, req *CreateTunnelRequestV5, timeout time.Duration,
+) (TunnelStateWithMessages, error) {
+	req.Protocol = string(H2CProtocol)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	return c.create(ctx, req)
+}
+
 // ListAllTunnelStates returns all the tunnels (including not currently running)
 // for a given user.
 func (c *Client) ListAllTunnelStates(limit int) ([]TunnelState, error) {

--- a/client_tunnel.go
+++ b/client_tunnel.go
@@ -5,15 +5,15 @@ import (
 	"time"
 )
 
-// CreateTunnel requests Sauce Labs REST API to create a new tunnel.
-func (c *Client) CreateTunnel(
-	ctx context.Context, request *CreateTunnelRequestV4, timeout time.Duration,
+// CreateTunnelV4 requests Sauce Labs REST API to create a new tunnel.
+func (c *Client) CreateTunnelV4(
+	ctx context.Context, req *CreateTunnelRequestV4, timeout time.Duration,
 ) (TunnelStateWithMessages, error) {
+	req.Protocol = string(KGPProtocol)
 	ctx, cancel := context.WithTimeout(ctx, timeout)
-	// Releases resources if the request completes before timeout elapses.
 	defer cancel()
 
-	return c.create(ctx, request)
+	return c.create(ctx, req)
 }
 
 // ListAllTunnelStates returns all the tunnels (including not currently running)

--- a/client_tunnel.go
+++ b/client_tunnel.go
@@ -7,7 +7,7 @@ import (
 
 // CreateTunnel requests Sauce Labs REST API to create a new tunnel.
 func (c *Client) CreateTunnel(
-	ctx context.Context, request *Request, timeout time.Duration,
+	ctx context.Context, request *CreateTunnelRequestV4, timeout time.Duration,
 ) (TunnelStateWithMessages, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	// Releases resources if the request completes before timeout elapses.

--- a/client_types.go
+++ b/client_types.go
@@ -50,6 +50,20 @@ type CreateTunnelRequestV4 struct {
 	VMVersion        string   `json:"vm_version,omitempty"`
 }
 
+// CreateTunnelRequestV5 create Sauce Connect tunnel 5.X request.
+type CreateTunnelRequestV5 struct {
+	TunnelIdentifier      string   `json:"tunnel_identifier"`
+	Protocol              string   `json:"protocol"`
+	SharedTunnel          bool     `json:"shared_tunnel"`
+	TunnelPool            bool     `json:"tunnel_pool"`
+	TunnelDomains         []string `json:"tunnel_domains,omitempty"`
+	DirectDomains         []string `json:"direct_domains,omitempty"`
+	DenyDomains           []string `json:"deny_domains,omitempty"`
+	TLSResignDomains      []string `json:"tls_resign_domains,omitempty"`
+	TLSPassthroughDomains []string `json:"tls_passthrough_domains,omitempty"`
+	Metadata              Metadata `json:"metadata,omitempty"`
+}
+
 type ClientStatusRequest struct {
 	KGPConnected         bool    `json:"kgp_is_connected"`
 	StatusChangeDuration int64   `json:"kgp_seconds_since_last_status_change"`

--- a/client_types.go
+++ b/client_types.go
@@ -35,33 +35,37 @@ type Metadata struct {
 
 // CreateTunnelRequestV4 create Sauce Connect tunnel 4.X request.
 type CreateTunnelRequestV4 struct {
-	DirectDomains    []string `json:"direct_domains,omitempty"`
+	TunnelIdentifier *string `json:"tunnel_identifier"`
+	Protocol         string  `json:"protocol,omitempty"`
+	SharedTunnel     bool    `json:"shared_tunnel"`
+	TunnelPool       bool    `json:"tunnel_pool"`
+	NoProxyCaching   bool    `json:"no_proxy_caching"`
+	KGPPort          int     `json:"ssh_port"`
+
 	DomainNames      []string `json:"domain_names"`
-	ExtraInfo        string   `json:"extra_info,omitempty"`
+	DirectDomains    []string `json:"direct_domains,omitempty"`
 	FastFailRegexps  []string `json:"fast_fail_regexps,omitempty"`
-	Metadata         Metadata `json:"metadata"`
-	NoProxyCaching   bool     `json:"no_proxy_caching"`
 	NoSSLBumpDomains []string `json:"no_ssl_bump_domains,omitempty"`
-	Protocol         string   `json:"protocol,omitempty"`
-	SharedTunnel     bool     `json:"shared_tunnel"`
-	KGPPort          int      `json:"ssh_port"`
-	TunnelIdentifier *string  `json:"tunnel_identifier"`
-	TunnelPool       bool     `json:"tunnel_pool"`
-	VMVersion        string   `json:"vm_version,omitempty"`
+
+	ExtraInfo string   `json:"extra_info,omitempty"`
+	Metadata  Metadata `json:"metadata"`
+	VMVersion string   `json:"vm_version,omitempty"`
 }
 
 // CreateTunnelRequestV5 create Sauce Connect tunnel 5.X request.
 type CreateTunnelRequestV5 struct {
-	TunnelIdentifier      string   `json:"tunnel_identifier"`
-	Protocol              string   `json:"protocol"`
-	SharedTunnel          bool     `json:"shared_tunnel"`
-	TunnelPool            bool     `json:"tunnel_pool"`
+	TunnelIdentifier string `json:"tunnel_identifier"`
+	Protocol         string `json:"protocol"`
+	SharedTunnel     bool   `json:"shared_tunnel"`
+	TunnelPool       bool   `json:"tunnel_pool"`
+
 	TunnelDomains         []string `json:"tunnel_domains,omitempty"`
 	DirectDomains         []string `json:"direct_domains,omitempty"`
 	DenyDomains           []string `json:"deny_domains,omitempty"`
 	TLSResignDomains      []string `json:"tls_resign_domains,omitempty"`
 	TLSPassthroughDomains []string `json:"tls_passthrough_domains,omitempty"`
-	Metadata              Metadata `json:"metadata,omitempty"`
+
+	Metadata Metadata `json:"metadata,omitempty"`
 }
 
 type ClientStatusRequest struct {

--- a/client_types.go
+++ b/client_types.go
@@ -33,8 +33,8 @@ type Metadata struct {
 	Release       string            `json:"release"`
 }
 
-// Request for a new tunnel.
-type Request struct {
+// CreateTunnelRequestV4 create Sauce Connect tunnel 4.X request.
+type CreateTunnelRequestV4 struct {
 	DirectDomains    []string `json:"direct_domains,omitempty"`
 	DomainNames      []string `json:"domain_names"`
 	ExtraInfo        string   `json:"extra_info,omitempty"`

--- a/client_types.go
+++ b/client_types.go
@@ -33,51 +33,21 @@ type Metadata struct {
 	Release       string            `json:"release"`
 }
 
-//nolint:maligned
-type jsonRequest struct {
-	DirectDomains         *[]string `json:"direct_domains"`
-	DomainNames           []string  `json:"domain_names"`
-	ExtraInfo             *string   `json:"extra_info"`
-	FastFailRegexps       *[]string `json:"fast_fail_regexps"`
-	Metadata              Metadata  `json:"metadata"`
-	NoProxyCaching        bool      `json:"no_proxy_caching"`
-	NoSSLBumpDomains      *[]string `json:"no_ssl_bump_domains"`
-	Protocol              *string   `json:"protocol"`
-	SharedTunnel          bool      `json:"shared_tunnel"`
-	SquidConfig           *string   `json:"squid_config"`
-	SSHPort               int       `json:"ssh_port"`
-	TLSPassthroughDomains *[]string `json:"tls_passthrough_domains"`
-	TLSResignDomains      *[]string `json:"tls_resign_domains"`
-	TunnelIdentifier      *string   `json:"tunnel_identifier"`
-	TunnelPool            bool      `json:"tunnel_pool"`
-	VMVersion             *string   `json:"vm_version"`
-}
-
 // Request for a new tunnel.
-//
-//nolint:maligned
 type Request struct {
-	DomainNames      []string
-	TunnelIdentifier string
-
-	DirectDomains         []string
-	FastFailRegexps       []string
-	KGPPort               int
-	NoProxyCaching        bool
-	NoSSLBumpDomains      []string
-	Protocol              string
-	SharedTunnel          bool
-	TLSPassthroughDomains []string
-	TLSResignDomains      []string
-	TunnelPool            bool
-	VMVersion             string
-
-	// Metadata contains the request metadata.
-	Metadata Metadata
-
-	// Extra info. This is a string (which contains a JSON dict) to enable
-	// optional features and flags.
-	ExtraInfo string
+	DirectDomains    []string `json:"direct_domains,omitempty"`
+	DomainNames      []string `json:"domain_names"`
+	ExtraInfo        string   `json:"extra_info,omitempty"`
+	FastFailRegexps  []string `json:"fast_fail_regexps,omitempty"`
+	Metadata         Metadata `json:"metadata"`
+	NoProxyCaching   bool     `json:"no_proxy_caching"`
+	NoSSLBumpDomains []string `json:"no_ssl_bump_domains,omitempty"`
+	Protocol         string   `json:"protocol,omitempty"`
+	SharedTunnel     bool     `json:"shared_tunnel"`
+	KGPPort          int      `json:"ssh_port"`
+	TunnelIdentifier *string  `json:"tunnel_identifier"`
+	TunnelPool       bool     `json:"tunnel_pool"`
+	VMVersion        string   `json:"vm_version,omitempty"`
 }
 
 type ClientStatusRequest struct {

--- a/client_vpn.go
+++ b/client_vpn.go
@@ -7,7 +7,7 @@ import (
 
 // CreateVPNProxy requests Sauce Labs REST API to start a new proxy over VPN.
 func (c *Client) CreateVPNProxy(
-	ctx context.Context, request *Request, timeout time.Duration,
+	ctx context.Context, request *CreateTunnelRequestV4, timeout time.Duration,
 ) (TunnelStateWithMessages, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	request.Protocol = string(VPNProtocol)

--- a/client_vpn.go
+++ b/client_vpn.go
@@ -7,14 +7,13 @@ import (
 
 // CreateVPNProxy requests Sauce Labs REST API to start a new proxy over VPN.
 func (c *Client) CreateVPNProxy(
-	ctx context.Context, request *CreateTunnelRequestV4, timeout time.Duration,
+	ctx context.Context, req *CreateTunnelRequestV4, timeout time.Duration,
 ) (TunnelStateWithMessages, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
-	request.Protocol = string(VPNProtocol)
-	// Releases resources if the request completes before timeout elapses.
+	req.Protocol = string(VPNProtocol)
 	defer cancel()
 
-	return c.create(ctx, request)
+	return c.create(ctx, req)
 }
 
 // ListVPNProxies returns VPN proxy IDs for a given user.


### PR DESCRIPTION
jsonRequest is replaced with json tags + omitempty to avoid pointers.

We introduce:
* TunnelDomains,
* DirectDomains,
* DenyDomains,
* TLSPassthroughDomains and deprecate the old and/or unused fields.

This would support both 4.9 and 5.0 until we remove the deprecated fields.